### PR TITLE
Fix plpython parameter usage

### DIFF
--- a/sql/procedures/generate_state.sql
+++ b/sql/procedures/generate_state.sql
@@ -10,6 +10,14 @@ AS $$
 # All lookups are performed via on–demand SQL queries without in–memory caches.
 #
 
+def exec_query(query, params=None, types=None):
+    """Helper to run parameterized SQL using prepared statements."""
+    if params is None:
+        return plpy.execute(query)
+    plan = plpy.prepare(query, types or [])
+    return plpy.execute(plan, params)
+
+
 def run_activation(context):
     """
     Run one activation using the context (a dict with keys):
@@ -25,6 +33,13 @@ def run_activation(context):
     """
     current_activation_path = context.get('activation_path', "")
 
+    def exec_query(query, params=None, types=None):
+        """Helper to run parameterized SQL using prepared statements."""
+        if params is None:
+            return plpy.execute(query)
+        plan = plpy.prepare(query, types or [])
+        return plpy.execute(plan, params)
+
     # --- On–demand regeneration check.
     if context.get('is_regeneration'):
         sql_locked_check = """
@@ -34,7 +49,11 @@ def run_activation(context):
               AND get_activation_full_path(la.activation) = $2
             LIMIT 1
         """
-        res_locked = plpy.execute(sql_locked_check, [context['state_id'], current_activation_path])
+        res_locked = exec_query(
+            sql_locked_check,
+            [context['state_id'], current_activation_path],
+            ["integer", "text"],
+        )
         if res_locked.nrows() > 0:
             # Activation is locked; skip re–execution.
             def empty_gen():
@@ -43,9 +62,10 @@ def run_activation(context):
             return empty_gen()
         # For non–locked activations in regeneration mode, delete previous output rows.
         if context.get('activation_id'):
-            plpy.execute(
+            exec_query(
                 "DELETE FROM value WHERE state = $1 AND activation = $2",
-                [context['state_id'], context['activation_id']]
+                [context['state_id'], context['activation_id']],
+                ["integer", "integer"],
             )
     
     # --- On–demand unmasking check for the current activation.
@@ -55,16 +75,17 @@ def run_activation(context):
         if sep == '':
             parent_path = ''
             local_name = current_activation_path
-        res_unmask = plpy.execute(
+        res_unmask = exec_query(
             "SELECT check_unmasking($1, $2, $3) AS unmasked",
-            [context['root_mech_id'], parent_path, local_name]
+            [context['root_mech_id'], parent_path, local_name],
+            ["integer", "text", "text"],
         )
         if res_unmask.nrows() > 0 and res_unmask[0]['unmasked'] is not None:
             context['mech_id'] = res_unmask[0]['unmasked']
 
     # --- Look up the mechanism record.
     sql = "SELECT id, name, serialized FROM mechanism WHERE id = $1"
-    res = plpy.execute(sql, [context['mech_id']])
+    res = exec_query(sql, [context['mech_id']], ["integer"])
     if res.nrows() == 0:
         plpy.error("Mechanism with id %s not found" % context['mech_id'])
     mech = res[0]
@@ -109,13 +130,18 @@ def run_activation(context):
             AND v.state = $3
             LIMIT 1
         """
-        res_val = plpy.execute(sql_val, [parent_path, output_name, context['state_id']])
+        res_val = exec_query(
+            sql_val,
+            [parent_path, output_name, context['state_id']],
+            ["text", "citext", "integer"],
+        )
         if res_val.nrows() == 0:
             plpy.error("No output found for resolved path: " + resolved)
         # Record the dependency: current (child) activation used the parent's output.
-        plpy.execute(
+        exec_query(
             "INSERT INTO value_antecedent(value, child, antecedent) VALUES ($1, $2, $3) ON CONFLICT DO NOTHING",
-            [res_val[0]['value_id'], context['activation_id'], res_val[0]['antecedent']]
+            [res_val[0]['value_id'], context['activation_id'], res_val[0]['antecedent']],
+            ["integer", "integer", "integer"],
         )
         return res_val[0]['value']
 
@@ -126,7 +152,11 @@ def run_activation(context):
             WHERE state = $1 AND activation = $2 AND name = $3 
             LIMIT 1
         """
-        res_dup = plpy.execute(sql_dup, [context['state_id'], context['activation_id'], name])
+        res_dup = exec_query(
+            sql_dup,
+            [context['state_id'], context['activation_id'], name],
+            ["integer", "integer", "citext"],
+        )
         if res_dup.nrows() > 0:
             plpy.error("Output with name '%s' already exists in the current activation" % name)
         value_type_val = 'number' if isinstance(value, (int, float)) else 'string'
@@ -135,12 +165,24 @@ def run_activation(context):
             VALUES ($1, $2, $3, $4)
             RETURNING id
         """
-        res_ins = plpy.execute(sql_ins, [context['state_id'], context['activation_id'], name, value_type_val])
+        res_ins = exec_query(
+            sql_ins,
+            [context['state_id'], context['activation_id'], name, value_type_val],
+            ["integer", "integer", "citext", "value_type"],
+        )
         value_id = res_ins[0]['id']
         if value_type_val == 'number':
-            plpy.execute("INSERT INTO number_value(value, serialized) VALUES ($1, $2)", [value_id, float(value)])
+            exec_query(
+                "INSERT INTO number_value(value, serialized) VALUES ($1, $2)",
+                [value_id, float(value)],
+                ["integer", "float8"],
+            )
         else:
-            plpy.execute("INSERT INTO string_value(value, serialized) VALUES ($1, $2)", [value_id, str(value)])
+            exec_query(
+                "INSERT INTO string_value(value, serialized) VALUES ($1, $2)",
+                [value_id, str(value)],
+                ["integer", "text"],
+            )
         return value
 
     def activate(mechanism_name, local_activation_name=None):
@@ -149,12 +191,20 @@ def run_activation(context):
         new_activation_path = current_activation_path + "/" + local_activation_name if current_activation_path else local_activation_name
         # Check for duplicate activation on–demand.
         sql_check = "SELECT 1 FROM activation WHERE get_activation_full_path(id) = $1 LIMIT 1"
-        res_check = plpy.execute(sql_check, [new_activation_path])
+        res_check = exec_query(
+            sql_check,
+            [new_activation_path],
+            ["text"],
+        )
         if res_check.nrows() > 0:
             plpy.error("Activation with name '%s' already exists in the current activation" % local_activation_name)
         # Look up the mechanism id for the requested mechanism.
         sql_lookup = "SELECT id FROM mechanism WHERE name = $1 LIMIT 1"
-        res_lookup = plpy.execute(sql_lookup, [mechanism_name])
+        res_lookup = exec_query(
+            sql_lookup,
+            [mechanism_name],
+            ["citext"],
+        )
         if res_lookup.nrows() == 0:
             plpy.error("Mechanism with name %s not found" % mechanism_name)
         new_mech_id = res_lookup[0]['id']
@@ -165,7 +215,11 @@ def run_activation(context):
             VALUES ($1, $2, $3, $4)
             RETURNING id
         """
-        res_act = plpy.execute(sql_act, [local_activation_name, context['mech_id'], context['root_mech_id'], new_mech_id])
+        res_act = exec_query(
+            sql_act,
+            [local_activation_name, context['mech_id'], context['root_mech_id'], new_mech_id],
+            ["citext", "integer", "integer", "integer"],
+        )
         new_activation_id = res_act[0]['id']
         # Prepare the child context.
         child_context = {
@@ -179,9 +233,10 @@ def run_activation(context):
         }
 
         # On–demand unmasking for the child activation using the stored function.
-        res_child_unmask = plpy.execute(
+        res_child_unmask = exec_query(
             "SELECT check_unmasking($1, $2, $3) AS unmasked",
-            [context['root_mech_id'], current_activation_path, local_activation_name]
+            [context['root_mech_id'], current_activation_path, local_activation_name],
+            ["integer", "text", "text"],
         )
         if res_child_unmask.nrows() > 0 and res_child_unmask[0]['unmasked'] is not None:
             child_context['mech_id'] = res_child_unmask[0]['unmasked']
@@ -193,7 +248,7 @@ def run_activation(context):
 
         # Confirm that the activation exists.
         sql_get = "SELECT id FROM activation WHERE get_activation_full_path(id) = $1 LIMIT 1"
-        res_get = plpy.execute(sql_get, [full_path])
+        res_get = exec_query(sql_get, [full_path], ["text"])
         if res_get.nrows() == 0:
             plpy.error("Activation with resolved path %s not found" % full_path)
         
@@ -209,7 +264,11 @@ def run_activation(context):
                     WHERE get_activation_full_path(a.id) LIKE $2
             )
         """
-        plpy.execute(sql_reject, [context['state_id'], pattern])
+        exec_query(
+            sql_reject,
+            [context['state_id'], pattern],
+            ["integer", "text"],
+        )
     
     # Prepare a namespace for the mechanism code.
     local_ns = {
@@ -250,7 +309,7 @@ def trampoline(root_context):
 
 # 1. Look up the entity and its root mechanism.
 sql_entity = "SELECT id, mechanism FROM entity WHERE name = $1 LIMIT 1"
-res_entity = plpy.execute(sql_entity, [p_entity_name])
+res_entity = exec_query(sql_entity, [p_entity_name], ["citext"])
 if res_entity.nrows() == 0:
     plpy.error("Entity with name '%s' not found" % p_entity_name)
 entity_rec = res_entity[0]
@@ -259,11 +318,12 @@ root_mech_id = entity_rec['mechanism']
 
 # 2. Look up or create the state for the entity at the given time.
 sql_state = "SELECT id FROM state WHERE entity = $1 AND time = $2 LIMIT 1"
-res_state = plpy.execute(sql_state, [entity_id, p_time])
+res_state = exec_query(sql_state, [entity_id, p_time], ["integer", "float8"])
 if res_state.nrows() == 0:
-    res_insert = plpy.execute(
-        "INSERT INTO state(entity, time) VALUES ($1, $2) RETURNING id", 
-        [entity_id, p_time]
+    res_insert = exec_query(
+        "INSERT INTO state(entity, time) VALUES ($1, $2) RETURNING id",
+        [entity_id, p_time],
+        ["integer", "float8"],
     )
     state_id = res_insert[0]['id']
     is_regeneration = False


### PR DESCRIPTION
## Summary
- update `generate_state` to prepare statements before executing them with parameters

## Testing
- `psql sahuagin -f sql/procedures/generate_state.sql`
- `psql sahuagin -c "CALL generate_state('ent1', 0);"`

------
https://chatgpt.com/codex/tasks/task_e_68492ca4145c832b9e2aeaf6447ac0b9