### PR TITLE
Add working mechanism examples and fix path function

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,3 +21,18 @@ sudo -u postgres pgcli sahuagin
 ## Schema
 
 All tables, functions, and procedures are organized in separate files under `sql/`. The original Jupyter notebooks are kept in `notebooks/` for historical reference.
+
+## Example usage
+
+After loading `sql/00_init.sql`, the script `sql/examples/test_generation.sql`
+creates two minimal mechanisms, generates states and a grouping, and runs both
+initial generation and regeneration of states.
+
+Run it with:
+
+```bash
+sudo -u postgres psql -d sahuagin -f sql/examples/test_generation.sql
+```
+
+This demonstrates the stored procedures `create_mechanism`, `generate_state`
+and `generate_grouping` in action.

--- a/sql/examples/test_generation.sql
+++ b/sql/examples/test_generation.sql
@@ -1,0 +1,55 @@
+
+-- Helper mechanism used by number_mech to actually emit the output
+CALL create_mechanism('number_worker', $PYTHON$
+def main():
+    add_output('num', 42)
+    if False:
+        yield
+$PYTHON$);
+
+-- Root numeric mechanism activates the worker
+CALL create_mechanism('number_mech', $PYTHON$
+import uuid
+def main():
+    unique_name = 'num_' + uuid.uuid4().hex[:8]
+    yield from activate('number_worker', unique_name)
+$PYTHON$);
+
+-- Helper mechanism used by string_mech to emit the greeting
+CALL create_mechanism('string_worker', $PYTHON$
+def main():
+    add_output('msg', 'hello')
+    if False:
+        yield
+$PYTHON$);
+
+-- Root string mechanism activates the worker
+CALL create_mechanism('string_mech', $PYTHON$
+import uuid
+def main():
+    unique_name = 'msg_' + uuid.uuid4().hex[:8]
+    yield from activate('string_worker', unique_name)
+$PYTHON$);
+
+-- Create an entity that uses the numeric mechanism
+INSERT INTO entity (mechanism, name)
+SELECT id, 'num_entity' FROM mechanism WHERE name = 'number_mech';
+
+-- Initial state generation for the entity
+CALL generate_state('num_entity', 0);
+
+-- Regenerate the same state by clearing previous records
+TRUNCATE state, activation, value, number_value, string_value,
+        value_antecedent, locked_activation, locked_dependency
+        RESTART IDENTITY CASCADE;
+CALL generate_state('num_entity', 0);
+
+-- Create a grouping of two string mechanism entities
+CALL generate_grouping('string_mech', 'demo_group', 'demo_%s', 2);
+
+-- View grouping results at time 0 (optional)
+-- SELECT * FROM get_grouping_at_time('demo_group', 0);
+
+-- Regenerate each grouped entity
+CALL generate_state('demo_1', 0);
+CALL generate_state('demo_2', 0);

--- a/sql/functions/get_activation_full_path.sql
+++ b/sql/functions/get_activation_full_path.sql
@@ -4,17 +4,17 @@ LANGUAGE plpgsql
 STABLE
 AS $$
 DECLARE
-    full_path text;
+    result_path text;
 BEGIN
     WITH RECURSIVE act_path AS (
         -- Start with the given activation.
-        SELECT 
+        SELECT
             id,
             name,
             from_mechanism,
             root_mechanism,
             to_mechanism,
-            name AS full_path
+            name::text AS full_path
         FROM activation
         WHERE id = activation_id
 
@@ -36,7 +36,7 @@ BEGIN
     )
     -- The root activation in the chain will have no parent – i.e. no activation
     -- exists such that its to_mechanism equals this activation's from_mechanism.
-    SELECT full_path INTO full_path
+    SELECT full_path INTO result_path
     FROM act_path
     WHERE NOT EXISTS (
         SELECT 1 
@@ -46,7 +46,7 @@ BEGIN
     )
     LIMIT 1;
     
-    RETURN full_path;
+    RETURN result_path;
 END;
 $$;
 


### PR DESCRIPTION
## Summary
- update get_activation_full_path to cast full_path and rename variable
- expand example generation script with worker mechanisms and unique activation names
- reset tables in example script to show regeneration

## Testing
- `sudo -u postgres createdb testdb`
- `sudo -u postgres psql -c "SELECT 1;" postgres`
- `sudo -u postgres dropdb testdb`
- `sudo -u postgres psql -d sahuagin -f sql/00_init.sql`
- `sudo -u postgres psql -d sahuagin -f sql/examples/test_generation.sql`


------
https://chatgpt.com/codex/tasks/task_e_684930c9d280832b820d0bfa5e5a0a58