### PR TITLE
Remove plpy/json from validation namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,4 +35,54 @@ sudo -u postgres psql -d sahuagin -f sql/examples/test_generation.sql
 ```
 
 This demonstrates the stored procedures `create_mechanism`, `generate_state`
-and `generate_grouping` in action.
+and `generate_grouping` in action. Each mechanism stores a single Python module
+with a required `generate()` function. The same module may optionally define
+`validate(state)`, which the `validate_state` function executes on a JSON
+representation of an entity state.
+
+The example also defines a `combo_mech` which composes `number_mech` and
+`string_mech`. Its validator illustrates delegating checks to child
+mechanisms using the `delegate()` helper and reading nested values with
+`use_input()`:
+
+```sql
+-- def validate(state):
+--     num_ok = delegate('number_mech', state['number'])
+--     str_ok = delegate('string_mech', state['string'])
+--     return num_ok and str_ok and use_input('number/num') == 42
+--
+-- SELECT validate_state('combo_mech', '{"number":{"num":42},"string":{"msg":"hello"}}');
+```
+
+## Validation workflow
+
+When creating a mechanism you supply a single Python module. It **must**
+define `generate()` for state generation and **may** define `validate(state)`.
+The module is stored in the `mechanism.module` column. `validate_state('<mechanism>', '<json>')` loads this module and exposes
+`delegate()` and `use_input()` to it. Validators can call
+`delegate(mechanism_name, state_fragment)` to invoke another mechanism's
+validator and use `use_input(path)` to read values from the provided state
+using `/`-separated paths.
+No other modules (such as `plpy` or `json`) are available inside the
+validator; use only these helpers when inspecting the input or delegating to
+other mechanisms.
+
+A short example:
+
+```sql
+CALL create_mechanism('number_mech',
+$PYTHON$
+import uuid
+
+def generate():
+    yield from activate('number_worker', 'num_' + uuid.uuid4().hex[:8])
+
+def validate(state):
+    return use_input('num') == 42
+$PYTHON$);
+
+SELECT validate_state('number_mech', '{"num":42}');
+```
+
+Calling `validate_state('number_mech', '{"num":42}')` will execute the
+`validate` function defined in the module.

--- a/sql/00_init.sql
+++ b/sql/00_init.sql
@@ -4,6 +4,7 @@
 \ir functions/debug_log.sql
 \ir functions/get_activation_full_path.sql
 \ir functions/check_unmasking.sql
+\ir functions/validate_state.sql
 \ir procedures/create_mechanism.sql
 \ir procedures/create_unmasking.sql
 \ir procedures/lock_value.sql

--- a/sql/examples/test_generation.sql
+++ b/sql/examples/test_generation.sql
@@ -1,7 +1,7 @@
 
 -- Helper mechanism used by number_mech to actually emit the output
 CALL create_mechanism('number_worker', $PYTHON$
-def main():
+def generate():
     add_output('num', 42)
     if False:
         yield
@@ -10,14 +10,18 @@ $PYTHON$);
 -- Root numeric mechanism activates the worker
 CALL create_mechanism('number_mech', $PYTHON$
 import uuid
-def main():
+
+def generate():
     unique_name = 'num_' + uuid.uuid4().hex[:8]
     yield from activate('number_worker', unique_name)
+
+def validate(state):
+    return use_input('num') == 42
 $PYTHON$);
 
 -- Helper mechanism used by string_mech to emit the greeting
 CALL create_mechanism('string_worker', $PYTHON$
-def main():
+def generate():
     add_output('msg', 'hello')
     if False:
         yield
@@ -26,9 +30,13 @@ $PYTHON$);
 -- Root string mechanism activates the worker
 CALL create_mechanism('string_mech', $PYTHON$
 import uuid
-def main():
+
+def generate():
     unique_name = 'msg_' + uuid.uuid4().hex[:8]
     yield from activate('string_worker', unique_name)
+
+def validate(state):
+    return use_input('msg') == 'hello'
 $PYTHON$);
 
 -- Create an entity that uses the numeric mechanism
@@ -53,3 +61,24 @@ CALL generate_grouping('string_mech', 'demo_group', 'demo_%s', 2);
 -- Regenerate each grouped entity
 CALL generate_state('demo_1', 0);
 CALL generate_state('demo_2', 0);
+
+-- Composed mechanism that activates number_mech and string_mech
+CALL create_mechanism('combo_mech', $PYTHON$
+import uuid
+
+def generate():
+    yield from activate('number_mech', 'num_' + uuid.uuid4().hex[:8])
+    yield from activate('string_mech', 'str_' + uuid.uuid4().hex[:8])
+
+def validate(state):
+    num_ok = delegate('number_mech', state.get('number'))
+    str_ok = delegate('string_mech', state.get('string'))
+    return (
+        num_ok and str_ok and
+        use_input('number/num') == 42 and
+        use_input('string/msg') == 'hello'
+    )
+$PYTHON$);
+
+-- Example validation call
+-- SELECT validate_state('combo_mech', '{"number":{"num":42},"string":{"msg":"hello"}}');

--- a/sql/functions/validate_state.sql
+++ b/sql/functions/validate_state.sql
@@ -1,0 +1,46 @@
+CREATE OR REPLACE FUNCTION validate_state(
+    p_mechanism_name CITEXT,
+    p_state_json TEXT
+) RETURNS BOOLEAN
+LANGUAGE plpython3u
+AS $$
+import json
+module_plan = plpy.prepare("SELECT module FROM mechanism WHERE name = $1", ["citext"])
+res = plpy.execute(module_plan, [p_mechanism_name])
+if res.nrows() == 0:
+    plpy.error("Mechanism with name '%s' not found" % p_mechanism_name)
+module_code = res[0]['module']
+if module_code is None:
+    plpy.error("No module stored for mechanism '%s'" % p_mechanism_name)
+state_data = json.loads(p_state_json)
+
+validate_plan = plpy.prepare("SELECT validate_state($1, $2) AS ok", ["citext", "text"])
+
+def delegate(mech_name, part_state):
+    res = plpy.execute(validate_plan, [mech_name, json.dumps(part_state)])
+    return bool(res[0]['ok'])
+
+def lookup_path(data, path):
+    current = data
+    for part in path.strip('/').split('/'):
+        if part == '':
+            continue
+        if isinstance(current, dict) and part in current:
+            current = current[part]
+        else:
+            plpy.error('use_input path not found: %s' % path)
+    return current
+
+def use_input(path):
+    return lookup_path(state_data, path)
+
+local_ns = {'delegate': delegate, 'use_input': use_input}
+exec(module_code, local_ns)
+validate_fn = local_ns.get('validate')
+if validate_fn is None:
+    plpy.error("Mechanism '%s' does not define validate()" % p_mechanism_name)
+try:
+    return bool(validate_fn(state_data))
+except Exception as e:
+    plpy.error('Validation failed: %s' % e)
+$$;

--- a/sql/procedures/create_mechanism.sql
+++ b/sql/procedures/create_mechanism.sql
@@ -1,14 +1,14 @@
 CREATE OR REPLACE PROCEDURE create_mechanism(
     p_mechanism_name CITEXT,
-    p_serialized_code TEXT
+    p_module_code TEXT
 )
 LANGUAGE plpgsql
 AS $$
 DECLARE
     v_mech_id INTEGER;
 BEGIN
-    INSERT INTO mechanism (name, serialized)
-    VALUES (p_mechanism_name, p_serialized_code)
+    INSERT INTO mechanism (name, module)
+    VALUES (p_mechanism_name, p_module_code)
     RETURNING id INTO v_mech_id;
     
     RAISE NOTICE 'Mechanism "%" created with id %.', p_mechanism_name, v_mech_id;

--- a/sql/procedures/generate_state.sql
+++ b/sql/procedures/generate_state.sql
@@ -29,7 +29,7 @@ def run_activation(context):
       - activation_path: full (slash–separated) activation path so far,
       - is_regeneration: boolean flag.
     
-    Returns the generator produced by executing the mechanism's main() code.
+    Returns the generator produced by executing the mechanism's generate() code.
     """
     current_activation_path = context.get('activation_path', "")
 
@@ -84,7 +84,7 @@ def run_activation(context):
             context['mech_id'] = res_unmask[0]['unmasked']
 
     # --- Look up the mechanism record.
-    sql = "SELECT id, name, serialized FROM mechanism WHERE id = $1"
+    sql = "SELECT id, name, module FROM mechanism WHERE id = $1"
     res = exec_query(sql, [context['mech_id']], ["integer"])
     if res.nrows() == 0:
         plpy.error("Mechanism with id %s not found" % context['mech_id'])
@@ -277,10 +277,10 @@ def run_activation(context):
         'activate': activate,
         'reject': reject,
     }
-    exec(mech['serialized'], local_ns)
-    if 'main' not in local_ns:
-        plpy.error("Mechanism code does not define a main() generator")
-    return local_ns['main']()
+    exec(mech['module'], local_ns)
+    if 'generate' not in local_ns:
+        plpy.error("Mechanism code does not define a generate() generator")
+    return local_ns['generate']()
 
 def trampoline(root_context):
     """

--- a/sql/schema/tables.sql
+++ b/sql/schema/tables.sql
@@ -2,7 +2,7 @@ DROP TABLE IF EXISTS mechanism CASCADE;
 CREATE TABLE mechanism (
   id integer GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
   name citext NOT NULL UNIQUE,
-  serialized text NOT NULL
+  module text NOT NULL
 );
 
 -- Activation table now links mechanisms.


### PR DESCRIPTION
## Summary
- don't expose `plpy` or `json` to mechanism validators
- document validation helpers in README
- clean up example to not import json
- clarify validator environment constraints

## Testing
- `sudo -u postgres createdb sah_test`
- `sudo -u postgres psql -d sah_test -f sql/00_init.sql`
- `sudo -u postgres psql -d sah_test -f sql/examples/test_generation.sql`
- `sudo -u postgres psql -d sah_test -c "SELECT validate_state('combo_mech', '{\"number\":{\"num\":42},\"string\":{\"msg\":\"hello\"}}') AS valid;" -P tuples_only`
- `sudo -u postgres psql -d sah_test -c "SELECT validate_state('combo_mech', '{\"number\":{\"num\":41},\"string\":{\"msg\":\"hello\"}}') AS valid;" -P tuples_only`
- `sudo -u postgres dropdb sah_test`


------
https://chatgpt.com/codex/tasks/task_e_6849f03fc2b8832bbbbdc82ac5a9f0a1