### PR TITLE
Add docker-compose setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,19 @@
+name: CI
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    container:
+      build:
+        context: .
+        dockerfile: Dockerfile
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run tests
+        run: |
+          pytest -v

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM ubuntu:24.04
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    python3 python3-pip sudo postgresql postgresql-contrib \
+    postgresql-plpython3-16 \
+    && rm -rf /var/lib/apt/lists/*
+RUN pip3 install --no-cache-dir pytest
+WORKDIR /workspace
+COPY . /workspace
+COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
+RUN chmod +x /usr/local/bin/docker-entrypoint.sh
+ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]
+CMD ["pytest", "-v"]

--- a/README.md
+++ b/README.md
@@ -43,10 +43,18 @@ The example also defines a `combo_mech` that composes `number_mech` and `string_
 
 ## Development
 
-Tests require PostgreSQL to be installed locally and can be run with:
+Tests require PostgreSQL. You can either install it locally or use the provided
+Docker setup. To run tests directly on your machine:
 
 ```bash
 pytest
+```
+
+Alternatively, build the container and execute the tests via
+`docker-compose`:
+
+```bash
+docker compose run --rm test
 ```
 
 ## License

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,10 @@
+version: '3.9'
+services:
+  test:
+    build: .
+    volumes:
+      - .:/workspace
+    environment:
+      DB_NAME: sahuagin_test
+    command: pytest -v
+

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+set -e
+service postgresql start
+exec "$@"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,10 @@
+import subprocess
+import pytest
+from . import helpers
+
+@pytest.fixture(scope='module', autouse=True)
+def db():
+    subprocess.run(['sudo', '-u', 'postgres', 'createdb', helpers.DB_NAME], check=True)
+    subprocess.run(['sudo', '-u', 'postgres', 'psql', '-d', helpers.DB_NAME, '-f', str(helpers.SQL_INIT)], check=True)
+    yield
+    subprocess.run(['sudo', '-u', 'postgres', 'dropdb', helpers.DB_NAME], check=True)

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,0 +1,14 @@
+import subprocess
+import pathlib
+import os
+
+DB_NAME = os.environ.get('DB_NAME', 'sahuagin_test')
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+SQL_INIT = ROOT / 'sql' / '00_init.sql'
+
+def run_psql(args, *, expect_success=True):
+    cmd = ['sudo', '-u', 'postgres', 'psql', '-v', 'ON_ERROR_STOP=1', '-d', DB_NAME] + args
+    result = subprocess.run(cmd, capture_output=True, text=True)
+    if expect_success and result.returncode != 0:
+        raise RuntimeError(f"psql failed: {result.stderr}")
+    return result

--- a/tests/test_create_mechanism.py
+++ b/tests/test_create_mechanism.py
@@ -1,28 +1,5 @@
-import subprocess
-import pathlib
 import textwrap
-import os
-import pytest
-
-DB_NAME = 'sahuagin_test'
-ROOT = pathlib.Path(__file__).resolve().parents[1]
-SQL_INIT = ROOT / 'sql' / '00_init.sql'
-
-
-def run_psql(args, *, expect_success=True):
-    cmd = ['sudo', '-u', 'postgres', 'psql', '-v', 'ON_ERROR_STOP=1', '-d', DB_NAME] + args
-    result = subprocess.run(cmd, capture_output=True, text=True)
-    if expect_success and result.returncode != 0:
-        raise RuntimeError(f"psql failed: {result.stderr}")
-    return result
-
-
-@pytest.fixture(scope="module", autouse=True)
-def db():
-    subprocess.run(['sudo', '-u', 'postgres', 'createdb', DB_NAME], check=True)
-    subprocess.run(['sudo', '-u', 'postgres', 'psql', '-d', DB_NAME, '-f', str(SQL_INIT)], check=True)
-    yield
-    subprocess.run(['sudo', '-u', 'postgres', 'dropdb', DB_NAME], check=True)
+from .helpers import ROOT, run_psql
 
 
 def test_create_mechanism_unique_violation():

--- a/tests/test_create_unmasking.py
+++ b/tests/test_create_unmasking.py
@@ -1,27 +1,5 @@
-import subprocess
-import pathlib
 import textwrap
-import pytest
-
-DB_NAME = 'sahuagin_test'
-ROOT = pathlib.Path(__file__).resolve().parents[1]
-SQL_INIT = ROOT / 'sql' / '00_init.sql'
-
-
-def run_psql(args, *, expect_success=True):
-    cmd = ['sudo', '-u', 'postgres', 'psql', '-v', 'ON_ERROR_STOP=1', '-d', DB_NAME] + args
-    result = subprocess.run(cmd, capture_output=True, text=True)
-    if expect_success and result.returncode != 0:
-        raise RuntimeError(f"psql failed: {result.stderr}")
-    return result
-
-
-@pytest.fixture(scope="module", autouse=True)
-def db():
-    subprocess.run(['sudo', '-u', 'postgres', 'createdb', DB_NAME], check=True)
-    subprocess.run(['sudo', '-u', 'postgres', 'psql', '-d', DB_NAME, '-f', str(SQL_INIT)], check=True)
-    yield
-    subprocess.run(['sudo', '-u', 'postgres', 'dropdb', DB_NAME], check=True)
+from .helpers import ROOT, run_psql
 
 
 def test_create_unmasking_removes_state():

--- a/tests/test_generate_grouping.py
+++ b/tests/test_generate_grouping.py
@@ -1,27 +1,5 @@
-import subprocess
-import pathlib
 import textwrap
-import pytest
-
-DB_NAME = 'sahuagin_test'
-ROOT = pathlib.Path(__file__).resolve().parents[1]
-SQL_INIT = ROOT / 'sql' / '00_init.sql'
-
-
-def run_psql(args, *, expect_success=True):
-    cmd = ['sudo', '-u', 'postgres', 'psql', '-v', 'ON_ERROR_STOP=1', '-d', DB_NAME] + args
-    result = subprocess.run(cmd, capture_output=True, text=True)
-    if expect_success and result.returncode != 0:
-        raise RuntimeError(f"psql failed: {result.stderr}")
-    return result
-
-
-@pytest.fixture(scope="module", autouse=True)
-def db():
-    subprocess.run(['sudo', '-u', 'postgres', 'createdb', DB_NAME], check=True)
-    subprocess.run(['sudo', '-u', 'postgres', 'psql', '-d', DB_NAME, '-f', str(SQL_INIT)], check=True)
-    yield
-    subprocess.run(['sudo', '-u', 'postgres', 'dropdb', DB_NAME], check=True)
+from .helpers import ROOT, run_psql
 
 
 def test_generate_grouping_creates_entities_and_state():

--- a/tests/test_lock_value.py
+++ b/tests/test_lock_value.py
@@ -1,28 +1,5 @@
-import subprocess
-import pathlib
 import textwrap
-import os
-import pytest
-
-DB_NAME = 'sahuagin_test'
-ROOT = pathlib.Path(__file__).resolve().parents[1]
-SQL_INIT = ROOT / 'sql' / '00_init.sql'
-
-
-def run_psql(args, *, expect_success=True):
-    cmd = ['sudo', '-u', 'postgres', 'psql', '-v', 'ON_ERROR_STOP=1', '-d', DB_NAME] + args
-    result = subprocess.run(cmd, capture_output=True, text=True)
-    if expect_success and result.returncode != 0:
-        raise RuntimeError(f"psql failed: {result.stderr}")
-    return result
-
-
-@pytest.fixture(scope="module", autouse=True)
-def db():
-    subprocess.run(['sudo', '-u', 'postgres', 'createdb', DB_NAME], check=True)
-    subprocess.run(['sudo', '-u', 'postgres', 'psql', '-d', DB_NAME, '-f', str(SQL_INIT)], check=True)
-    yield
-    subprocess.run(['sudo', '-u', 'postgres', 'dropdb', DB_NAME], check=True)
+from .helpers import ROOT, run_psql
 
 
 def test_lock_value_dependency_closure():

--- a/tests/test_regeneration.py
+++ b/tests/test_regeneration.py
@@ -1,27 +1,5 @@
-import subprocess
-import pathlib
 import textwrap
-import pytest
-
-DB_NAME = 'sahuagin_test'
-ROOT = pathlib.Path(__file__).resolve().parents[1]
-SQL_INIT = ROOT / 'sql' / '00_init.sql'
-
-
-def run_psql(args, *, expect_success=True):
-    cmd = ['sudo', '-u', 'postgres', 'psql', '-v', 'ON_ERROR_STOP=1', '-d', DB_NAME] + args
-    result = subprocess.run(cmd, capture_output=True, text=True)
-    if expect_success and result.returncode != 0:
-        raise RuntimeError(f"psql failed: {result.stderr}")
-    return result
-
-
-@pytest.fixture(scope="module", autouse=True)
-def db():
-    subprocess.run(['sudo', '-u', 'postgres', 'createdb', DB_NAME], check=True)
-    subprocess.run(['sudo', '-u', 'postgres', 'psql', '-d', DB_NAME, '-f', str(SQL_INIT)], check=True)
-    yield
-    subprocess.run(['sudo', '-u', 'postgres', 'dropdb', DB_NAME], check=True)
+from .helpers import ROOT, run_psql
 
 
 def test_regeneration_skips_locked_activation():

--- a/tests/test_validate_state.py
+++ b/tests/test_validate_state.py
@@ -1,27 +1,5 @@
-import subprocess
-import pathlib
 import textwrap
-import pytest
-
-DB_NAME = 'sahuagin_test'
-ROOT = pathlib.Path(__file__).resolve().parents[1]
-SQL_INIT = ROOT / 'sql' / '00_init.sql'
-
-
-def run_psql(args, *, expect_success=True):
-    cmd = ['sudo', '-u', 'postgres', 'psql', '-v', 'ON_ERROR_STOP=1', '-d', DB_NAME] + args
-    result = subprocess.run(cmd, capture_output=True, text=True)
-    if expect_success and result.returncode != 0:
-        raise RuntimeError(f"psql failed: {result.stderr}")
-    return result
-
-
-@pytest.fixture(scope='module', autouse=True)
-def db():
-    subprocess.run(['sudo', '-u', 'postgres', 'createdb', DB_NAME], check=True)
-    subprocess.run(['sudo', '-u', 'postgres', 'psql', '-d', DB_NAME, '-f', str(SQL_INIT)], check=True)
-    yield
-    subprocess.run(['sudo', '-u', 'postgres', 'dropdb', DB_NAME], check=True)
+from .helpers import ROOT, run_psql
 
 
 def test_validate_state():


### PR DESCRIPTION
## Summary
- add a simple docker-compose file for running tests
- document running tests with docker-compose

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684fcd5c3dfc832b94a26b009496031f